### PR TITLE
Correct ip of Http LBR

### DIFF
--- a/_docs/projects/nautilus.md
+++ b/_docs/projects/nautilus.md
@@ -46,7 +46,7 @@ The Nautilus is a three-tier application and is deployed in the Stratos Datacent
 |stapp01         | 172.16.238.10 | stapp01.stratos.xfusioncorp.com |tony |Ir0nM@n|Nautilus App 1
 |stapp02         | 172.16.238.11 | stapp02.stratos.xfusioncorp.com |steve |Am3ric@|Nautilus App 2
 |stapp03         | 172.16.238.12 | stapp03.stratos.xfusioncorp.com | banner |BigGr33n|Nautilus App 3
-|stlb01          | 172.16.238.14 | stlb01.stratos.xfusioncorp.com |loki |Mischi3f|Nautilus HTTP LBR
+|stlb01          | 172.16.238.13 | stlb01.stratos.xfusioncorp.com |loki |Mischi3f|Nautilus HTTP LBR
 |stdb01          | 172.16.239.10 | stdb01.stratos.xfusioncorp.com |peter |Sp!dy|Nautilus DB Server
 |ststor01        |172.16.238.15  | ststor01.stratos.xfusioncorp.com |natasha |Bl@kW|Stork DC Storage Filer
 |stbkp01         | 172.16.238.16 | stbkp01.stratos.xfusioncorp.com |clint |H@wk3y3| Nautilus Backup Server


### PR DESCRIPTION
The Entry of Nautilus Http Load Balancer(stlb01) ip on all hosts 172.16.238.13 in /etc/hosts.